### PR TITLE
Split nested klass name to words

### DIFF
--- a/lib/changeling/models/logling.rb
+++ b/lib/changeling/models/logling.rb
@@ -16,9 +16,9 @@ module Changeling
       property :modified_at, :type => 'date'
 
       mapping do
-        indexes :klass, :type => "string"
-        indexes :oid, :type => "string"
-        indexes :modified_by, :type => "string"
+        indexes :klass, :type => 'string'
+        indexes :oid, :type => 'string'
+        indexes :modified_by, :type => 'string'
         indexes :modifications, :type => 'string'
         indexes :modified_fields, :type => 'string', :analyzer => 'keyword'
         indexes :modified_at, :type => 'date'
@@ -48,7 +48,7 @@ module Changeling
 
         def records_for(object, length = nil, field = nil)
           filters = [
-            { :klass => Logling.klassify(object) },
+            { :klass => Logling.klassify(object).split('/') },
             { :oid => object.id.to_s }
           ]
 

--- a/lib/changeling/models/logling.rb
+++ b/lib/changeling/models/logling.rb
@@ -8,9 +8,9 @@ module Changeling
       include Tire::Model::Callbacks
       include Tire::Model::Persistence
 
-      property :klass, :type => 'string'
-      property :oid, :type => 'string'
-      property :modified_by, :type => 'string'
+      property :klass, :type => "string"
+      property :oid, :type => "string"
+      property :modified_by, :type => "string"
       property :modifications, :type => 'string'
       property :modified_fields, :type => 'string', :analyzer => 'keyword'
       property :modified_at, :type => 'date'

--- a/lib/changeling/support/search.rb
+++ b/lib/changeling/support/search.rb
@@ -18,7 +18,9 @@ module Changeling
             filtered do
               query { all }
               filters.each do |f|
-                filter :terms, { f.first[0].to_sym => Array(f.first[1]).map(&:to_s) }
+                filter :terms, {
+                  f.first[0].to_sym => Array(f.first[1]).map(&:to_s)
+                }
               end
             end
           end

--- a/lib/changeling/support/search.rb
+++ b/lib/changeling/support/search.rb
@@ -18,7 +18,7 @@ module Changeling
             filtered do
               query { all }
               filters.each do |f|
-                filter :terms, { f.first[0].to_sym => [f.first[1].to_s] }
+                filter :terms, { f.first[0].to_sym => Array(f.first[1]).map(&:to_s) }
               end
             end
           end

--- a/spec/lib/changeling/models/logling_spec.rb
+++ b/spec/lib/changeling/models/logling_spec.rb
@@ -33,7 +33,7 @@ describe Changeling::Models::Logling do
           context "when passed object is a ElasticSearch response hash" do
             before(:each) do
               @object = {
-                "klass"=>"BlogPost",
+                "klass"=>["BlogPost"],
                 "oid"=>"50b8355f7a93d04908000001",
                 "modifications"=>"{\"public\":[true,false]}",
                 "modified_at"=>"2012-11-29T20:26:07-08:00"
@@ -189,7 +189,7 @@ describe Changeling::Models::Logling do
           it "should search with filters on the klass and oid" do
             expect(@search).to receive(:find_by).with(hash_including({
               :filters => [
-                { :klass => @klass.klassify(@object) },
+                { :klass => [@klass.klassify(@object)] },
                 { :oid => @object.id.to_s }
               ]
             })).and_return(@results)
@@ -199,7 +199,7 @@ describe Changeling::Models::Logling do
           it "should search with a filter on the field if one is passed in" do
             expect(@search).to receive(:find_by).with(hash_including(
               :filters => [
-                { :klass => @klass.klassify(@object) },
+                { :klass => [@klass.klassify(@object)] },
                 { :oid => @object.id.to_s },
                 { :modified_fields => "field" }
               ]


### PR DESCRIPTION
ElasticSearch reverse index `nested/class_name` into two, e.g. `nested` and `class_name`. When use `object.loglings`, no data is found with filter term on `klass => ['nested/class_name']`.

This diff change it to filter term with `klass => ['nested', 'class_name']`.

This is a backward compatible fix to support nested class name.

A better fix would change the mapping to use `not_analyzed` index. Then no split required.

```
indexes :klass, :type => "string", :index => :not_analyzed
```

https://www.elastic.co/guide/en/elasticsearch/guide/current/mapping-intro.html#_index_2
https://www.elastic.co/guide/en/elasticsearch/guide/current/_finding_exact_values.html

Test:

```
results = Changeling::Models::Logling.search per_page: 10 do
  query do
    filtered do
      query { all }
      filter :terms, { klass: ['incentive/scheme'] }
      filter :terms, { oid: ['1'] }
    end
  end
end.results # => [] empty array
```

```
results = Changeling::Models::Logling.search per_page: 10 do
  query do
    filtered do
      query { all }
      filter :terms, { klass: ['incentive', 'scheme'] }
      filter :terms, { oid: ['1'] }
    end
  end
end.results # => [#<Changeling::Models::Logling:0x007f567a8ef878>]
```
